### PR TITLE
fix warning about comparison of unsigned < 0 is always false

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -420,7 +420,7 @@ public:
 
     CScript& operator<<(opcodetype opcode)
     {
-        if (opcode < 0 || opcode > 0xff)
+        if (opcode > OP_INVALIDOPCODE)
             throw std::runtime_error("CScript::operator<<(): invalid opcode");
         insert(end(), (unsigned char)opcode);
         return *this;


### PR DESCRIPTION
opcode has type unsigned enum