### PR TITLE
Updated mining requires peers logic (Fixes #105)

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -425,7 +425,7 @@ void static BitcoinMiner(const CChainParams& chainparams)
                         LOCK(cs_vNodes);
                         fvNodesEmpty = vNodes.empty();
                     }
-                    if (!fvNodesEmpty && !IsInitialBlockDownload() && masternodeSync.IsSynced())
+                    if (!fvNodesEmpty && !IsInitialBlockDownload() && ((chainActive.Tip()->nHeight < chainparams.GetConsensus().nMasternodePaymentsIncreaseBlock) || masternodeSync.IsSynced()))
                         break;
                     MilliSleep(1000);
                 } while (true);


### PR DESCRIPTION
Updated mining requires peers logic to make it possible to mine without a masternode sync having completed. This has some important
implications:

1) A masternode must exist by the time the masternode payments start
block goes into effect
2) All miners need to agree at which point the masternode sync is
required before mining

Fixes #105