### PR TITLE
updating miner requiring masternode sync logic

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,8 +93,7 @@ public:
         consensus.nSubsidyHalvingInterval = 210240; /* Older value */ // Note: actual number of blocks per calendar year with DGW v3 is ~200700 (for example 449750 - 249050)
         consensus.nSubsidyHalvingInterval = 41540; /*  */
 
-        /*does not matter for ENERGI.. payment is consistent forever*/
-        consensus.nMasternodePaymentsStartBlock = 100000; // not true, but it's ok as long as it's less then nMasternodePaymentsIncreaseBlock
+        consensus.nMasternodePaymentsStartBlock = 87600; // should be about 2 months after genesis
         consensus.nMasternodePaymentsIncreaseBlock = 158000; // actual historical value
         consensus.nMasternodePaymentsIncreasePeriod = 576*30; // 17280 - actual historical value
         consensus.nInstantSendKeepLock = 24;
@@ -246,7 +245,7 @@ public:
 				+ consensus.nBlockSubsidyMiners );
 
         /*does not matter for ENERGI.. payment is consistent forever*/
-        consensus.nMasternodePaymentsStartBlock = 0; // not true, but it's ok as long as it's less then nMasternodePaymentsIncreaseBlock
+        consensus.nMasternodePaymentsStartBlock = 87600; // should be about 2 months after genesis
         consensus.nMasternodePaymentsIncreaseBlock =  46000;
         consensus.nMasternodePaymentsIncreasePeriod = 576;
         consensus.nInstantSendKeepLock = 6;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -425,7 +425,7 @@ void static BitcoinMiner(const CChainParams& chainparams)
                         LOCK(cs_vNodes);
                         fvNodesEmpty = vNodes.empty();
                     }
-                    if (!fvNodesEmpty && !IsInitialBlockDownload() && ((chainActive.Tip()->nHeight < chainparams.GetConsensus().nMasternodePaymentsIncreaseBlock) || masternodeSync.IsSynced()))
+                    if (!fvNodesEmpty && !IsInitialBlockDownload() && ((chainActive.Tip()->nHeight < chainparams.GetConsensus().nMasternodePaymentsStartBlock) || masternodeSync.IsSynced()))
                         break;
                     MilliSleep(1000);
                 } while (true);


### PR DESCRIPTION
* set masternode payment start block to 87600 (about 2 months from genesis)
* use masternode payment start block, not increase block, to determine when it's okay to mine without a masternode sync