### PR TITLE
Change mn collateral type to camount to avoid overflow

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -24,7 +24,7 @@ static const int MASTERNODE_NEW_START_REQUIRED_SECONDS  = 180 * 60;
 
 static const int MASTERNODE_POSE_BAN_MAX_SCORE          = 5;
 
-static const int MASTERNODE_COLLATERAL_AMOUNT = 10000*COIN;
+static const CAmount MASTERNODE_COLLATERAL_AMOUNT = 10000*COIN;
 
 //
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network


### PR DESCRIPTION
Minor change: As pointed out by @levongh, the MN collateral constant needed to be bigger than int to avoid potential overflow. 