### PR TITLE
Uncomment lines that penalize peers

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -133,7 +133,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
             if(netfulfilledman.HasFulfilledRequest(pfrom->addr, NetMsgType::MNGOVERNANCESYNC)) {
                 // Asking for the whole list multiple times in a short period of time is no good
                 LogPrint("gobject", "MNGOVERNANCESYNC -- peer already asked me for the list\n");
-                // Misbehaving(pfrom->GetId(), 20);
+                Misbehaving(pfrom->GetId(), 20);
                 return;
             }
             netfulfilledman.AddFulfilledRequest(pfrom->addr, NetMsgType::MNGOVERNANCESYNC);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -358,7 +358,7 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, std::string& strCommand, 
         if(netfulfilledman.HasFulfilledRequest(pfrom->addr, NetMsgType::MASTERNODEPAYMENTSYNC)) {
             // Asking for the payments list multiple times in a short period of time is no good
             LogPrintf("MASTERNODEPAYMENTSYNC -- peer already asked me for the list, peer=%d\n", pfrom->id);
-            // Misbehaving(pfrom->GetId(), 20);
+            Misbehaving(pfrom->GetId(), 20);
             return;
         }
         netfulfilledman.AddFulfilledRequest(pfrom->addr, NetMsgType::MASTERNODEPAYMENTSYNC);


### PR DESCRIPTION
Haven't been able to reproduce the misbehaving peers error, even though I had these lines uncommented locally. The hypothesis is that it's because there's a masternode on the network now. May or may not be the case, but for now, we can resume normal behavior while being on the lookout for the problem. 

Related to #118 