### PR TITLE
Changed min percentage of absolute votes required for a full signal

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -113,7 +113,7 @@ public:
         consensus.nSuperblockStartBlock = 0; //
         consensus.nSuperblockCycle = 16616; // ~(60*24*30)/2.6, actual number of blocks per month is 200700 / 12 = 16725
 
-        consensus.nGovernanceMinQuorum = 10;
+        consensus.nGovernanceMinQuorum = 7; // Minimum 7 votes required for full signal
         consensus.nGovernanceFilterElements = 20000;
 
         consensus.nMasternodeMinimumConfirmations = 15;

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -691,7 +691,7 @@ void CGovernanceObject::UpdateSentinelVariables()
     // CALCULATE THE MINUMUM VOTE COUNT REQUIRED FOR FULL SIGNAL
 
     // todo - 12.1 - should be set to `10` after governance vote compression is implemented
-    int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nMnCount / 10);
+    int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nMnCount / MIN_FRACTION_ABS_VOTES_REQ_FOR_FULL_SIGNAL);
     int nAbsDeleteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, (2 * nMnCount) / 3);
     // todo - 12.1 - Temporarily set to 1 for testing - reverted
     //nAbsVoteReq = 1;

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -52,6 +52,8 @@ static const int SEEN_OBJECT_ERROR_IMMATURE = 2;
 static const int SEEN_OBJECT_EXECUTED = 3; //used for triggers
 static const int SEEN_OBJECT_UNKNOWN = 4; // the default
 
+static const int MIN_FRACTION_ABS_VOTES_REQ_FOR_FULL_SIGNAL = 7;
+
 typedef std::pair<CGovernanceVote, int64_t> vote_time_pair_t;
 
 inline bool operator<(const vote_time_pair_t& p1, const vote_time_pair_t& p2)


### PR DESCRIPTION
For Energi we will have a shorter budget cycle, so to increase responsiveness we will lower this threshold to 7%.

More details: https://github.com/energicryptocurrency/energi/issues/136