### PR TITLE
Changed min percentage of absolute MNs required for a full signal

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -691,7 +691,7 @@ void CGovernanceObject::UpdateSentinelVariables()
     // CALCULATE THE MINUMUM VOTE COUNT REQUIRED FOR FULL SIGNAL
 
     // todo - 12.1 - should be set to `10` after governance vote compression is implemented
-    int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nMnCount / 10);
+    int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, (nMnCount*7)/100); // 7%  of the voters
     int nAbsDeleteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, (2 * nMnCount) / 3);
     // todo - 12.1 - Temporarily set to 1 for testing - reverted
     //nAbsVoteReq = 1;


### PR DESCRIPTION
For Energi we will have a shorter budget cycle, so to increase responsiveness we lower  MNs required for a full signal to 7%.

More details: #136