### PR TITLE
'-usedag' flag #139 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -494,6 +494,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-mnemonicpassphrase", _("User defined mnemonic passphrase for HD wallet (bip39). Only has effect during wallet creation/first start (default: empty string)"));
     strUsage += HelpMessageOpt("-hdseed", _("User defined seed for HD wallet (should be in hex). Only has effect during wallet creation/first start (default: randomly generated)"));
     strUsage += HelpMessageOpt("-upgradewallet", _("Upgrade wallet to latest format on startup"));
+    strUsage += HelpMessageOpt("-usedag", strprintf(_("Whether to operate in full or light mode (default: %u)"), DEFAULT_USEDAG));
     strUsage += HelpMessageOpt("-wallet=<file>", _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), "wallet.dat"));
     strUsage += HelpMessageOpt("-walletbroadcast", _("Make the wallet broadcast transactions") + " " + strprintf(_("(default: %u)"), DEFAULT_WALLETBROADCAST));
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)"));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2548,6 +2548,11 @@ void CreateDAG(int height, egihash::progress_callback_type callback)
 {
     using namespace egihash;
 
+    if (!GetBoolArg("-usedag", DEFAULT_USEDAG)) {
+        LogPrintf("dag: Operating in light mode - skipping DAG creation (usedag=0)");
+        return;
+    }
+
     auto const epoch = height / constants::EPOCH_LENGTH;
     auto const & seedhash = seedhash_to_filename(get_seedhash(height));
     stringstream ss;

--- a/src/validation.h
+++ b/src/validation.h
@@ -132,6 +132,9 @@ static const bool DEFAULT_TESTSAFEMODE = false;
 /** Default for -mempoolreplacement */
 static const bool DEFAULT_ENABLE_REPLACEMENT = false;
 
+/** Default for -usedag */
+static const bool DEFAULT_USEDAG = false;
+
 /** Maximum number of headers to announce when relaying blocks with headers message.*/
 static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
 


### PR DESCRIPTION
Added ‘-usedag’ flag, default:false. 

TEST
Tested with setting  the value usedag=1/0  in energi.conf , and by passing as command line arg  
Verified by mining in both modes. 