### PR TITLE
early fail check prevents superblock

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -65,7 +65,7 @@ bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockRewar
     if (!isFoundationRewardValueMet)
     {
         LogPrint("gobject", "IsBlockValueValid -- coinbase does not pay correct Energi Foundation Amount");
-        return false;
+        isBlockRewardValueMet = false;
     }
 
     CAmount nSuperblockMaxValue =  blockReward + CSuperblock::GetPaymentsLimit(nBlockHeight);


### PR DESCRIPTION
Don't fail early if foundation payment not detected - it could be a superblock