### PR TITLE
Rl gbt regtest

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -494,17 +494,20 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     if (strMode != "template")
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
 
-    if(!g_connman)
-        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+    if (Params().NetworkIDString() != CBaseChainParams::REGTEST)
+    {
+        if(!g_connman)
+            throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
-    if (g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0)
-        throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Energi Core is not connected!");
+        if (g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0)
+            throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Energi Core is not connected!");
 
-    if (IsInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Energi Core is downloading blocks...");
+        if (IsInitialBlockDownload())
+            throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Energi Core is downloading blocks...");
 
-    if (!masternodeSync.IsSynced())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Energi Core is syncing with network...");
+        if (!masternodeSync.IsSynced())
+            throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Energi Core is syncing with network...");
+    }
 
     static unsigned int nTransactionsUpdatedLast;
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -696,7 +696,6 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
 
     auto const newBlockHeight = pindexPrev->nHeight + 1;
     bool const mnPaymentsStarted = (newBlockHeight >= Params().GetConsensus().nMasternodePaymentsStartBlock);
-    bool const superblocksStarted = newBlockHeight >= Params().GetConsensus().nSuperblockCycle;
 
     result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
     result.push_back(Pair("transactions", transactions));
@@ -749,7 +748,6 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         }
     }
     result.push_back(Pair("superblock", superblockObjArray));
-    result.push_back(Pair("superblocks_started", superblocksStarted));
     result.push_back(Pair("superblocks_enabled", sporkManager.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED)));
 
     return result;


### PR DESCRIPTION
* don't require peer connections and masternode sync for `getblocktemplate` on the regtest network
* removed `superblocks_started` member of `getblocktemplate` - is always true for Energi