### PR TITLE
Rl fix sync issues

### DIFF
--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -91,16 +91,6 @@ uint256 CBlockHeader::GetPOWHash() const
 
 uint256 CBlockHeader::GetHash() const
 {
-    if (std::memcmp(hashMix.begin(), &(egihash::empty_h256.b[0]), (std::min)(egihash::empty_h256.hash_size, static_cast<egihash::h256_t::size_type>(hashMix.size()))) == 0)
-    {
-        // nonce is used to populate
-        GetPOWHash();
-        if (std::memcmp(hashMix.begin(), &(egihash::empty_h256.b[0]), (std::min)(egihash::empty_h256.hash_size, static_cast<egihash::h256_t::size_type>(hashMix.size()))) == 0)
-        {
-            error("Can not produce a valid mixhash");
-        }
-    }
-
     // return a Keccak-256 hash of the full block header, including nonce and mixhash
     CBlockHeaderFullLE fullBlockHeader(*this);
     egihash::h256_t blockHash(&fullBlockHeader, sizeof(fullBlockHeader));

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -27,7 +27,7 @@ public:
     uint32_t nTime;
     uint32_t nBits;
     uint32_t nHeight;
-    mutable uint256 hashMix;
+    uint256 hashMix;
     uint32_t nNonce;
 
     CBlockHeader()
@@ -69,6 +69,10 @@ public:
 
     /** GetPOWHash() returns the egihash used to satisfy the proof of work condition.
     *       The first time this is computed, the hashMix is stored.
+    */
+    uint256 GetPOWHash();
+
+    /** GetPOWHash() returns the egihash used to satisfy the proof of work condition.
     */
     uint256 GetPOWHash() const;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3345,11 +3345,6 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
 {
     AssertLockHeld(cs_main);
 
-    // if we have a block height this far in the future, someone is purposely submitting bad blocks
-    // further this must be rejected before we try to compute a block hash - otherwise we could ask for a DAG/cache way in the future
-    if (block.nHeight > (chainActive.Height() + 100))
-        return state.DoS(100, error("%s: invalid block height", __func__), REJECT_INVALID, "bad-blk-height");
-
     // Check for duplicate
     uint256 hash = block.GetHash();
     BlockMap::iterator miSelf = mapBlockIndex.find(hash);


### PR DESCRIPTION
PR #243 caused issues with clients on the initial sync if the blockchain had gotten too far ahead.

This addresses the issue in the following ways:
1) we check proof of work after checking the previous block, which prevents the problems with bad block heights being submitted
2) We don't compute the proof of work hash just to compute the block's final hash. We must have the mixhash already in the block header.

Because of 2) There are some changes about the genesis blocks, which now manually call `GetPOWHash()` to ensure they are populated correctly.