### PR TITLE
Rl p2sh backbone

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -285,7 +285,6 @@ public:
 
         genesis = CreateGenesisBlock(1390095618, 28917698, 0x1e0ffff0, 1, consensus.nBlockSubsidyBackbone + consensus.nBlockSubsidyMiners);
         bool const valid_genesis_pow = GenesisCheckProofOfWork(genesis.GetPOWHash(), genesis.nBits, consensus);
-        //assert(valid_genesis_pow);
         consensus.hashGenesisBlock = genesis.GetHash();
 
         // TODO: mine genesis block for main net
@@ -299,6 +298,7 @@ public:
         //}
         //#endif // ENERGI_MINE_NEW_GENESIS_BLOCK
 //
+        //assert(valid_genesis_pow);
         //assert(consensus.hashGenesisBlock == expectedGenesisHash);
         //assert(genesis.hashMerkleRoot == expectedGenesisMerkleRoot);
 
@@ -439,7 +439,6 @@ public:
 
         genesis = CreateGenesisBlock(1521239519UL, 12501313, 0x1e0ffff0, 1, consensus.nBlockSubsidyBackbone + consensus.nBlockSubsidyMiners);
         bool const valid_genesis_pow = GenesisCheckProofOfWork(genesis.GetPOWHash(), genesis.nBits, consensus);
-        assert(valid_genesis_pow);
         consensus.hashGenesisBlock = genesis.GetHash();
 
         uint256 expectedGenesisHash = uint256S("0x404555947d9a66370f6842c632662b9fae6dd90ef2bf03871af4c4b780ac93f6");
@@ -453,6 +452,7 @@ public:
         }
         #endif // ENERGI_MINE_NEW_GENESIS_BLOCK
 
+        assert(valid_genesis_pow);
         assert(consensus.hashGenesisBlock == expectedGenesisHash);
         assert(genesis.hashMerkleRoot == expectedGenesisMerkleRoot);
 
@@ -573,7 +573,6 @@ public:
 
         genesis = CreateGenesisBlock(1521240281UL, 39305453, 0x1e0ffff0, 1, consensus.nBlockSubsidyBackbone + consensus.nBlockSubsidyMiners);
         bool const valid_genesis_pow = GenesisCheckProofOfWork(genesis.GetPOWHash(), genesis.nBits, consensus);
-        assert(valid_genesis_pow);
         consensus.hashGenesisBlock = genesis.GetHash();
         uint256 expectedGenesisHash = uint256S("0x5c5a96d7284da7a7c250b6ad2f301893e0f0a61bea4d4a5e009c758e4ea7c39a");
         uint256 expectedGenesisMerkleRoot = uint256S("0x0bb0036bbae578cff5e636a197895f25b7242eeebc0272e91db3ebfb9a73843c");
@@ -586,6 +585,7 @@ public:
         }
         #endif // ENERGI_MINE_NEW_GENESIS_BLOCK
 
+        assert(valid_genesis_pow);
         assert(consensus.hashGenesisBlock == expectedGenesisHash);
         assert(genesis.hashMerkleRoot == expectedGenesisMerkleRoot);
 
@@ -712,7 +712,6 @@ public:
 
         genesis = CreateGenesisBlock(1521320241UL, 5, 0x207fffff, 1, consensus.nBlockSubsidyBackbone + consensus.nBlockSubsidyMiners);
         bool const valid_genesis_pow = GenesisCheckProofOfWork(genesis.GetPOWHash(), genesis.nBits, consensus);
-        assert(valid_genesis_pow);
         consensus.hashGenesisBlock = genesis.GetHash();
 
         uint256 expectedGenesisHash = uint256S("0x1fa5bf921cdb7d6daa35ceb88da3cbe9b2ae0dbc0c906b6aa8001879ecbe3ea1");
@@ -725,6 +724,7 @@ public:
         }
         #endif // ENERGI_MINE_NEW_GENESIS_BLOCK
 
+        assert(valid_genesis_pow);
         assert(consensus.hashGenesisBlock == expectedGenesisHash);
         assert(genesis.hashMerkleRoot == expectedGenesisMerkleRoot);
         vFixedSeeds.clear(); //! Regtest mode doesn't have any fixed seeds.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -304,10 +304,10 @@ public:
 
         vSeeds.push_back(CDNSSeedData("energi.network", "dnsseed.energi.network"));
 
-        // Energi addresses start with 'N'
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,53);
-        // Energi script addresses start with 'R'
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,60);
+        // Energi addresses start with 'E'
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,33);
+        // Energi script addresses start with 'N'
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,53);
         // Energi private keys start with 'G'
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,106);
         // Energi BIP32 pubkeys start with 'npub'

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -198,7 +198,7 @@ public:
         strNetworkID = "main";
 
         // Energi distribution parameters
-        consensus.energiBackboneAddress = "TODO: implement me";
+        consensus.energiBackboneScript = CScript() << OP_HASH160 << ParseHex("TODO: IMPLEMENT ME") << OP_EQUAL;
 
         // Seeing as there are 526,000 blocks per year, and there is a 12M annual emission
         // masternodes get 30% of all coins or 3.6M / 526,000 ~ 6.85
@@ -371,7 +371,7 @@ public:
         strNetworkID = "test";
 
         // Energi distribution parameters
-        consensus.energiBackboneAddress = "tA61JveN6y2kej9kYNK9tKvVuUgAvgaC6X";
+        consensus.energiBackboneScript = CScript() << OP_DUP << OP_HASH160 << ParseHex("22af89cb590829ae00a927deb2efbf81954c6840") << OP_EQUALVERIFY << OP_CHECKSIG;
 
         // Seeing as there are 526,000 blocks per year, and there is a 12M annual emission
         // masternodes get 30% of all coins or 3.6M / 526,000 ~ 6.85
@@ -509,7 +509,7 @@ public:
         strNetworkID = "test60";
 
         // Energi distribution parameters
-        consensus.energiBackboneAddress = "tA61JveN6y2kej9kYNK9tKvVuUgAvgaC6X";
+        consensus.energiBackboneScript = CScript() << OP_DUP << OP_HASH160 << ParseHex("22af89cb590829ae00a927deb2efbf81954c6840") << OP_EQUALVERIFY << OP_CHECKSIG;
         // Seeing as there are 526,000 blocks per year, and there is a 12M annual emission
         // masternodes get 30% of all coins or 3.6M / 526,000 ~ 6.85
         // miners get 20% of all coins or 2.4M / 526,000 ~ 4.57
@@ -641,7 +641,7 @@ public:
         strNetworkID = "regtest";
 
         // Energi distribution parameters
-        consensus.energiBackboneAddress = "tA61JveN6y2kej9kYNK9tKvVuUgAvgaC6X";
+        consensus.energiBackboneScript = CScript() << OP_HASH160 << ParseHex("b27ae40d9e9917130210894e50e99f26968faaa4") << OP_EQUAL;
 
         // Seeing as there are 526,000 blocks per year, and there is a 12M annual emission
         // masternodes get 30% of all coins or 3.6M / 526,000 ~ 6.85

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -304,16 +304,16 @@ public:
 
         vSeeds.push_back(CDNSSeedData("energi.network", "dnsseed.energi.network"));
 
-        // Energi addresses start with 'E'
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,33);
-        // Energi script addresses start with '3'
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
-        // Energi private keys start with e'
-        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,92);
-        // Energi BIP32 pubkeys start with 'xpub' (Bitcoin defaults)
-        base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x88)(0xB2)(0x1E).convert_to_container<std::vector<unsigned char> >();
-        // Energi BIP32 prvkeys start with 'xprv' (Bitcoin defaults)
-        base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x88)(0xAD)(0xE4).convert_to_container<std::vector<unsigned char> >();
+        // Energi addresses start with 'N'
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,53);
+        // Energi script addresses start with 'R'
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,60);
+        // Energi private keys start with 'G'
+        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,106);
+        // Energi BIP32 pubkeys start with 'npub'
+        base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x03)(0xB8)(0xC8)(0x56).convert_to_container<std::vector<unsigned char> >();
+        // Energi BIP32 prvkeys start with 'nprv'
+        base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0xD7)(0xDC)(0x6E)(0x9F).convert_to_container<std::vector<unsigned char> >();
 
         // Energi BIP44 coin type is '5'
         nExtCoinType = 5;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -8,6 +8,7 @@
 
 #include "amount.h"
 #include "uint256.h"
+#include "script/script.h"
 #include <map>
 #include <string>
 
@@ -86,7 +87,7 @@ struct Params {
     CAmount nRegularTreasuryBudget;
     CAmount nSpecialTreasuryBudget;
     uint32_t nSpecialTreasuryBudgetBlock;
-    std::string energiBackboneAddress;
+    CScript energiBackboneScript;
 };
 } // namespace Consensus
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -243,7 +243,12 @@ void CMasternodePayments::FillBlockBackbonePayment(CMutableTransaction& txNew, C
     txoutBackboneRet = CTxOut(backbonePayment, consensus.energiBackboneScript);
     txNew.vout.push_back(txoutBackboneRet);
 
-    LogPrintf("CMasternodePayments::FillBlockBackbonePayment -- Backbone payment %lld to %s\n", backbonePayment, txoutBackboneRet.GetHash().ToString());
+    CTxDestination txdestBackbone;
+    if (ExtractDestination(consensus.energiBackboneScript, txdestBackbone))
+    {
+        CBitcoinAddress backboneAddress(txdestBackbone);
+        LogPrintf("CMasternodePayments::FillBlockBackbonePayment -- Backbone payment %lld to %s\n", backbonePayment, backboneAddress.ToString());
+    }
 }
 
 /**

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -249,6 +249,10 @@ void CMasternodePayments::FillBlockBackbonePayment(CMutableTransaction& txNew, C
         CBitcoinAddress backboneAddress(txdestBackbone);
         LogPrintf("CMasternodePayments::FillBlockBackbonePayment -- Backbone payment %lld to %s\n", backbonePayment, backboneAddress.ToString());
     }
+    else
+    {
+        error("CMasternodePayments::FillBlockBackbonePayment -- Energi Backbone script is not valid.");
+    }
 }
 
 /**

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -45,18 +45,10 @@ bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockRewar
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
     // verify the Energi Backbone address payment
-    // TODO: is there a better way to search tx outputs?
     bool isBackboneRewardValueMet = false;
-    CBitcoinAddress backboneAddress(consensusParams.energiBackboneAddress);
-    CKeyID backboneKeyID;
-    if (!backboneAddress.GetKeyID(backboneKeyID))
-    {
-        error("Unable to get key ID for Energi Backbone address");
-    }
-    CScript backbonePubKey = GetScriptForDestination(backboneKeyID);
     for (auto const & i : block.vtx[0].vout)
     {
-        if ((i.scriptPubKey == backbonePubKey) && (i.nValue >= consensusParams.nBlockSubsidyBackbone))
+        if ((i.scriptPubKey == consensusParams.energiBackboneScript) && (i.nValue >= consensusParams.nBlockSubsidyBackbone))
         {
             isBackboneRewardValueMet = true;
             break;
@@ -244,26 +236,14 @@ void CMasternodePayments::FillBlockBackbonePayment(CMutableTransaction& txNew, C
     // make sure it's not filled yet
     txoutBackboneRet = CTxOut();
 
-    CBitcoinAddress backboneAddress(consensus.energiBackboneAddress);
-    CKeyID backboneKeyID;
-    if (!backboneAddress.GetKeyID(backboneKeyID))
-    {
-        error("Unable to get key ID for Energi Backbone address");
-    }
-    CScript payee = GetScriptForDestination(backboneKeyID);
-
     CAmount backbonePayment = consensus.nBlockSubsidyBackbone;
 
     // split reward between Energi Backbone, masternodes & miners
     txNew.vout[0].nValue -= backbonePayment;
-    txoutBackboneRet = CTxOut(backbonePayment, payee);
+    txoutBackboneRet = CTxOut(backbonePayment, consensus.energiBackboneScript);
     txNew.vout.push_back(txoutBackboneRet);
 
-    CTxDestination address1;
-    ExtractDestination(payee, address1);
-    CBitcoinAddress address2(address1);
-
-    LogPrintf("CMasternodePayments::FillBlockBackbonePayment -- Backbone payment %lld to %s\n", backbonePayment, address2.ToString());
+    LogPrintf("CMasternodePayments::FillBlockBackbonePayment -- Backbone payment %lld to %s\n", backbonePayment, txoutBackboneRet.GetHash().ToString());
 }
 
 /**

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -38,44 +38,44 @@ struct TestVector {
 
 TestVector test1 =
   TestVector("000102030405060708090a0b0c0d0e0f")
-    ("xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
-     "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+    ("npub2qgivhE1LcAokvcW6W1JDHEp7ah4vZH5EtDRksCpeAMaJtoh4h42AuTJLxZNTBCdEQ2qWfxE92b43QiETh4t7idLziwdd74m6qsZLYaCHsM",
+     "nprvGnNBAhy3NGmY3qWK2rKis7eg9evuPRjw18KsgU62SNkSEHByuheRraB2adBAhb5UinFoWAk5PeeccgrwkTJ4AxP6WvK2MrH3NpZcZyVTHFVg",
      0x80000000)
-    ("xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
-     "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+    ("npub2sx8vQXURsHnuXkDJFsw6KLvSQFRJdm5vVeKixawcMYrgB6sUvb7J3oi8E85CV7AEcKQNuVesff91ogNQioGBc65CMjtYQxycn17eAJZMsz",
+     "nprvGnQSahgLqN2f2z7Sk45bVzgnFykTjopR1owJaSBQZLwdWeUH67sxwhKNzQSX2znrgVJhCY3QG31TVQcyU6tLMkTB2zBhW6EkGXaFRQdrMeMV",
      1)
-    ("xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ",
-     "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
+    ("npub2v8G8C5MpaArjynf2Wmoh4EaVnEXJfVNrpKAKEMkYzM4uic1Cj1RFchwYJaecRpWCKwTAKwkzG9cc7RBt3y9sFv1VZak23yFFWXtw7QM8XR",
+     "nprvGnSchuTtikjY6pZVBnLVNbRfv38Sqor9JkFyR2TBNHaRit1nDqgPFetHDpVi6bidiwPStLrzh7iQuYZVhEE8LXcfUVxfE9zX8CNZnwYoLx2f",
      0x80000002)
-    ("xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
-     "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
+    ("npub2xjYAiuDXT2Gc9akH7BB44Giiw73aD5NCMYqZZeuiriWKZo81UqrA4Fs6KmV4JFpYr3BmhvNNCib4SZUb9Wgvi4r5TYt712vyCT32P4qJbt",
+     "nprvGnVDywziaTcPWgjHH2vtjxRi4GHKN5PjJ5oD6GnUXTSoAHryLeSDgZKq9NXviZx9DSrUGwKwcY8EommESpF3Xei78raDnJvm4oeK1aCAJFJw",
      2)
-    ("xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV",
-     "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
+    ("npub2zxw1A2AhvhFgd4TyNPFwZS2okPnCoPZdqS8pXBP3JH7gfRV5FYDMdinmeksU6QZ2AAMuiQKQwchcruUgSwteJY6zF74wBvkytMtAwAG2b8",
+     "nprvGnXTNnRqXe64VmCkzjC6pqvsNM6c6hz3VXH6PXjzzmtMmexbhiCv3kuJ53rLB2cYeWebyZFBBSwgyEx8u1fasr6hBFpJss1amxcnB5i1axyS",
      1000000000)
-    ("xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy",
-     "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
+    ("npub32ghUqdQq45TCxqv5uwzFGS2byy62JCbS5ph4oZXFNfcPnpsbfnscjsrQUfpKMVGVrSuR4L7x9KJDHJVnJSjVZhDrnX9jfWPnqyoR619ww7",
+     "nprvGnZB9G7SmmDShHYYSqjfZ9dsN9LBQXUrXKXUwn2P8yxkGN616EdAi21T8gi7NwXfj841ELcA8HzE6F89GYjbby4LibK56yvLVExLXpqMhnMp",
      0);
 
 TestVector test2 =
   TestVector("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542")
-    ("xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB",
-     "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U",
+    ("npub2qgivhE1LcAokY7qCf5afUxaMmqVcBXtvU1A3owecYUSbsptEqpxbocth4eMARZb8xGdRLcPY76JmCSTasz3FddHrf96TbZRRDYfcQwvekW",
+     "nprvGnNBAhy3NGmY3q7pMxUo9ZrPuu83p7NBpoufQm2mGM8Z6aB16soCo15CAyEwkmb2p2JYvv2XqvkeonPfrViSsZkRHNj6bzcx7PpEoLTh3PQx",
      0)
-    ("xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH",
-     "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt",
+    ("npub2txUCQuxpcztGoi8LSTTjHN6ijakKA2BUdkXDcy6gxLQHrGrp7B2keC9GXcExWa2MGkoHZc8wBwGvMs9U2gTbEHa8hsmMwhoYhfL3g9Zqev",
+     "nprvGnRSuygjKknN8MPQf6GB2deoSG5o4pLg7N5QmvqniRYR4G9T5T4Ys9umRYkDZQeseRxnkp2waMv4w8uJg3zwvVyagNuWfP77rXE9MhjKFzsZ",
      0xFFFFFFFF)
-    ("xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a",
-     "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
+    ("npub2v7XT1wVCXAzSfvJktT7Cd3f7UoereBsZnq491ssLh6nk9WKRzbLxhyjsurMiFB88ngLwQTkEQMsb2jVEwAaKNkCfnVpifxpR5vvtQYSxBb",
+     "nprvGnSbyEHkr8gYEXFcqWiAg6zUzeq1yMpqoTEVJrEhV5HBSiSgY4wyBMyZ2A6hY8uc8LC7eb49DQva3a93SnNZ45H2Eodk19cr7K1UtUAQX9wT",
      1)
-    ("xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon",
-     "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
+    ("npub2xvVs2vRNAUBYHbSpYbgAZytT1g9xq78tEKuz5YCeaTEQyNUjW83rcN7ii3VW7sQiy8tn3YysXfhfpzW9qbXaiD7G4hfwDQ2Lrbt8vBTsqH",
+     "nprvGnVQweJjnJKqRcsHyaNKF4wRDzMtUU1m4mfzAhJMpPAXtPGYhNTVtFswPztuAAcope9UMLMDbpUFFtqpbqG5S5kqXwQGozipVnoucwqufDoQ",
      0xFFFFFFFE)
-    ("xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL",
-     "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
+    ("npub2z6XmzrmyZRtqEq3Z2RDY5g5Mk9X1ojduw3oWoEcVLiUsKhQqB44P8jDMNAzhVPrgQnXaYcgv8zZKU9tqii3J4uZXy2AVWVSD5gTfncVMm2",
+     "nprvGnWayZGg8uio8upXaJr8nST7Qu6MqWzPZoNi4E24EDvo8qcsdU8RtnQJVdbdYo3C7Bim3eAzbCqpqhxuyMCyvmbWhmLp88vr88Pv91dQcq8u",
      2)
-    ("xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt",
-     "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
+    ("npub31TZjS5HVjk8aW1wH6YuWq43kogdG8eia6fgvab788a4wX2yzoypZhgDRmFGq4kZCTzkrU86or1YouDPfpPwcKm9B8rFRsnAtNseLV7kDqU",
+     "nprvGnXx1WhteRu7Nf5iU2vGURCVPJ9twmKJeTYKwdoQirieiupDCdmMexyFVi1JYx4HBE2cmvvdQewfXkWoV5XM9paFRaCKdCLyqpmFh69j6F8k",
      0);
 
 void RunTest(const TestVector &test) {

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)
 BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
 {
 
-    string strSecret = string("Ej3b3UtDHaLBAvnppRbpwzGHhYRBxjRrTvAK9cDYoEctCDVyE298");
+    string strSecret = string("GnoB4id9STZc9oB2eKTQkJq5VSuXTNuKqtAFYsoCf88KxypKEPS9");
     CBitcoinSecret vchSecret;
     BOOST_CHECK(vchSecret.SetString(strSecret));
 

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)
 BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
 {
 
-    string strSecret = string("GnoB4id9STZc9oB2eKTQkJq5VSuXTNuKqtAFYsoCf88KxypKEPS9");
+    string strSecret = string("Gh3RtaeBBCKAkBrE6apZy9mi7FgwfGba6V5cdk8dvegzfhe18Y4v");
     CBitcoinSecret vchSecret;
     BOOST_CHECK(vchSecret.SetString(strSecret));
 
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     filter.Serialize(stream, SER_NETWORK, PROTOCOL_VERSION);
 
-    vector<unsigned char> vch = ParseHex("03cc7592080000000000000001");
+    vector<unsigned char> vch = ParseHex("03c67291080000000000000001");
     vector<char> expected(vch.size());
 
     for (unsigned int i = 0; i < vch.size(); ++i) {

--- a/src/test/data/base58_keys_valid.json
+++ b/src/test/data/base58_keys_valid.json
@@ -1,6 +1,6 @@
 [
     [
-        "NdZvioAkVEwoju3YgdzcK5qJpoGvcMEiSq",
+        "Eaos2dCzHdgHPEFpCFLEcaPaEi84PAfJTn",
         "c1a7e32962dee960126497b3df1fd4072c93f503",
         {
             "addrType": "pubkey",
@@ -9,7 +9,7 @@
         }
     ],
     [
-        "RRHwHuMuX8P9BmzZyKv9R4ZqFEnQxkufp5",
+        "NbviQ9GtYs91Tk1xoPav2BfKqhyoy7ZoWv",
         "afa615ddffcfc364f952956c251bce5042e821bf",
         {
             "addrType": "script",
@@ -18,7 +18,7 @@
         }
     ],
     [
-        "Niyik5bajc22FoDZck7u8WwYohxge9d42s",
+        "EgDf3udpXzkVu8Rq8MTXS1VpDcopRjh9bp",
         "fd00802f8b61ccf0c1bb1c7969c832673ed546a9",
         {
             "addrType": "pubkey",
@@ -72,7 +72,7 @@
         }
     ],
     [
-        "NTuh9nnF4XUgUVkVPKtvk1jifCgk8ZNbx9",
+        "ER9dTcpUrvDA7pxktwEZ3WHz57XsqAXGEg",
         "57b39f318f3cd120e08a5f710850c03c22c213fc",
         {
             "addrType": "pubkey",
@@ -81,7 +81,7 @@
         }
     ],
     [
-        "RYPcG7wYNannbD4JTRTfKKvS15gdheBJFk",
+        "Nj2PNMrXQKYesB5hHV8RvT1vbYt2mBxqaz",
         "fd81935b46055357fd1d2af1ca12ef055f9b0cc0",
         {
             "addrType": "script",
@@ -153,7 +153,7 @@
         }
     ],
     [
-        "RJFPjAeGrDB9d7SqhwSRYfa9H9FBfVbBVs",
+        "NUtAqQZFsww1u5UEY17C9nfdscSaikYvH8",
         "6262063c2a4a0a638062aaff356d79c35600a821",
         {
             "addrType": "script",
@@ -216,7 +216,7 @@
         }
     ],
     [
-        "NP6STNbMiBQqXKzeQjmabXq4wRRHZ72bGJ",
+        "ELLNmCdbWa9KAfCuvM7Cu2PLMLGRM1uyYp",
         "22e34cda0ba9e2affb620720ae8a7797567da639",
         {
             "addrType": "pubkey",
@@ -225,7 +225,7 @@
         }
     ],
     [
-        "RJgDK2Q3tk245nS5zZG26Ai6yQZWNGPVF2",
+        "NVJzRGK2vUmvMkTUpcvnhHobZskuPbAyUv",
         "6713ba75a430dc678a402012a8fdc40fcf3c2ba5",
         {
             "addrType": "script",
@@ -288,7 +288,7 @@
         }
     ],
     [
-        "NUzvcxM1tDZ3TZtAVzxmUAE69hqwWsMBKB",
+        "ESErvnPFgcHX6u6S1cJPmenMZch5KWXfXu",
         "63a911fcd13311d90188b372b6f8ab7a853ef052",
         {
             "addrType": "pubkey",
@@ -297,7 +297,7 @@
         }
     ],
     [
-        "RPknoxL1XS4c9ZK7uFJSVBMTqeJjn5g293",
+        "NaPZvCEzZApURXLWjJyD6JSxS7W8odzgfn",
         "9ec9fc088ce0a02386c787227e699e50256edbae",
         {
             "addrType": "script",
@@ -306,7 +306,7 @@
         }
     ],
     [
-        "NceLhpDuHniBuEdCYVJMa2GbiTAXJnZz3G",
+        "EZtH1eG96BSfYZqU46dysWps8N1f48eSjN",
         "b785720a94fd55e6f1c738fc465918bdd4280464",
         {
             "addrType": "pubkey",
@@ -360,7 +360,7 @@
         }
     ],
     [
-        "Nf8c3GA1fy3GgBcUkaLKreQ1LaELjJxobG",
+        "EcNYM6CFUMmkKWpkGBfxA8xGkV5UX73AGJ",
         "d2ce252de1e1dd9d1205a9672b274f488d943c92",
         {
             "addrType": "pubkey",
@@ -369,7 +369,7 @@
         }
     ],
     [
-        "RP8auZAP1Fo8rJAuVyej1DmSfHJbiF2mwB",
+        "NZmN1o5N2zZ18GCJL3KVcLrwFkVzhPb65J",
         "97f112c9c50ac814a953202f485eedfd2cf856b5",
         {
             "addrType": "script",
@@ -432,7 +432,7 @@
         }
     ],
     [
-        "NQ7NKRirbkCr2WNN7sXfogoU6GiuHVqN2b",
+        "EMMJdFm6Q8wKfqaddUsJ7BMjWBa38nVMuD",
         "2e0863783ae131b41bcac197738de589881a59c9",
         {
             "addrType": "pubkey",
@@ -441,7 +441,7 @@
         }
     ],
     [
-        "RUdXr4oApSDoECjjPxUTBr4xLdSPZXKDHt",
+        "NfGJxJi9rAyfWAm8E29DnyASw6dndUsHnJ",
         "d44335f13c8d26c9ba5106b2d4f179ed5a650286",
         {
             "addrType": "script",

--- a/src/test/data/base58_keys_valid.json
+++ b/src/test/data/base58_keys_valid.json
@@ -1,6 +1,6 @@
 [
     [
-        "Eaos2dCzHdgHPEFpCFLEcaPaEi84PAfJTn",
+        "NdZvioAkVEwoju3YgdzcK5qJpoGvcMEiSq",
         "c1a7e32962dee960126497b3df1fd4072c93f503",
         {
             "addrType": "pubkey",
@@ -9,7 +9,7 @@
         }
     ],
     [
-        "3Hhm8vy4UCtxCwKodFbckAbZdVcXruM8a8",
+        "RRHwHuMuX8P9BmzZyKv9R4ZqFEnQxkufp5",
         "afa615ddffcfc364f952956c251bce5042e821bf",
         {
             "addrType": "script",
@@ -18,12 +18,12 @@
         }
     ],
     [
-        "EgDf3udpXzkVu8Rq8MTXS1VpDcopRjh9bp",
+        "Niyik5bajc22FoDZck7u8WwYohxge9d42s",
         "fd00802f8b61ccf0c1bb1c7969c832673ed546a9",
         {
             "addrType": "pubkey",
             "isPrivkey": false,
-            "isTestnet": false 
+            "isTestnet": false
         }
     ],
     [
@@ -36,7 +36,7 @@
         }
     ],
     [
-        "Effr9d878UgFfoZSx9VWEtrxL842HbznzT5Wmq1HyF2JX4btbcRY",
+        "Gjng9tAhadWBK3kChD21PLBmpCs9yTnyGdoLcBrcqwaGThRjMrYU",
         "6333e256bb02f09b3bb233c17c5e86562cc39571ac2eba07a92d99d1f6faeeac",
         {
             "isCompressed": true,
@@ -45,7 +45,7 @@
         }
     ],
     [
-        "EhFxc8v6Gjmv15pFSZYGtWkgJ96CQBeyJGPqkTiakcYL4EupYEzh",
+        "GmNncPxgitbqeL11Bd4n2x5VnDuL63T9aT7fapZudK6HzsjACw2C",
         "9296962c50327a60f78a11b6f017ea3b22182892fba9c976a765c5b014f25802",
         {
             "isCompressed": true,
@@ -72,7 +72,7 @@
         }
     ],
     [
-        "ER9dTcpUrvDA7pxktwEZ3WHz57XsqAXGEg",
+        "NTuh9nnF4XUgUVkVPKtvk1jifCgk8ZNbx9",
         "57b39f318f3cd120e08a5f710850c03c22c213fc",
         {
             "addrType": "pubkey",
@@ -81,7 +81,7 @@
         }
     ],
     [
-        "3QoS79YhKfJbcNPY7M98eRxAPLWkaisXXY",
+        "RYPcG7wYNannbD4JTRTfKKvS15gdheBJFk",
         "fd81935b46055357fd1d2af1ca12ef055f9b0cc0",
         {
             "addrType": "script",
@@ -108,7 +108,7 @@
         }
     ],
     [
-        "Eh6FtwSYgLH59sSd1K1VTXUrbESxzwQBbGaKsbcVGKngTMhTa8WM",
+        "GmD5uCV98V6zo7dNkNXzbxog5KG6goCMsTJ9hxTp92LePzTjxGaL",
         "8d98e24f45c472b2a04390fa80acc09ce2ce7d1ce041489fe5d9e8d89bdf6b2d",
         {
             "isCompressed": true,
@@ -117,7 +117,7 @@
         }
     ],
     [
-        "EiS4ibT7oN9txPaZtQ9HDfmGxy9NEDQGojjqJEsAhxCTtczjUv7N",
+        "GnYtirViFWypbdmKdTfnN766T3xVv5CT5vTf8biVaekRqFnb4y1X",
         "b59fcc3195c2d5e3ccb19956b0d513154cff959ec3acf9bb6004670d728fee56",
         {
             "isCompressed": true,
@@ -149,11 +149,11 @@
         {
             "addrType": "pubkey",
             "isPrivkey": false,
-            "isTestnet": true 
+            "isTestnet": true
         }
     ],
     [
-        "3AfDaCFRoHgxeGn5Ms7tsmbsfQ5JdaHPyf",
+        "RJFPjAeGrDB9d7SqhwSRYfa9H9FBfVbBVs",
         "6262063c2a4a0a638062aaff356d79c35600a821",
         {
             "addrType": "script",
@@ -180,7 +180,7 @@
         }
     ],
     [
-        "Ej3b3UtDHaLBAvnppRbpwzGHhYRBxjRrTvAK9cDYoEctCDVyE298",
+        "GoAR3jvojjA6pAyaZV8L6Rb7BdEKebE2k6t8yy4sfwAr8rLjZk8K",
         "c7e604df1cca9e700fd023b42495902d1c8eca2642df42543451b3124d9c7279",
         {
             "isCompressed": true,
@@ -189,7 +189,7 @@
         }
     ],
     [
-        "EfTHXR9SsWorWr27kqU33gYrzuCnJs5jgMVHNV6RUuCNUCYZbCGo",
+        "Gja7XgC3KfdnA6CsVtzYC7sgUz1uzisuxYD7CqwkMbkLQqLdZvQ6",
         "5cbd7421d9fbe6b3bc5b684da2054091da8a64b2a3ad25ab7960d452fd05b3ff",
         {
             "isCompressed": true,
@@ -216,7 +216,7 @@
         }
     ],
     [
-        "ELLNmCdbWa9KAfCuvM7Cu2PLMLGRM1uyYp",
+        "NP6STNbMiBQqXKzeQjmabXq4wRRHZ72bGJ",
         "22e34cda0ba9e2affb620720ae8a7797567da639",
         {
             "addrType": "pubkey",
@@ -225,7 +225,7 @@
         }
     ],
     [
-        "3B63A41CqpXs6wmKeUwVRGjqMfPdBSL64o",
+        "RJgDK2Q3tk245nS5zZG26Ai6yQZWNGPVF2",
         "6713ba75a430dc678a402012a8fdc40fcf3c2ba5",
         {
             "addrType": "script",
@@ -252,7 +252,7 @@
         }
     ],
     [
-        "Eegycyw24qQEG88Gxv6NLkbDqL2miwjDZGVHRBVumCxVPMRcGWkq",
+        "GioodEycWzE9uNK2hycsVBv3KQquQoXPqTD7FYMEduWTKzC8AAWn",
         "45f22c0ff5e0f588f710377c9c940ca11bfa920a2b5cc5ff4b6f115e8d2bc2d1",
         {
             "isCompressed": true,
@@ -261,7 +261,7 @@
         }
     ],
     [
-        "EhcNR2QeFtikrBx4VVa7eBY75xAHPQjsrApGtrQuHSLo8LuuArZv",
+        "GmjCRHTEi3YgVS8pEZ6cncrva2yR5GY48MY6jDGEA8tm4ygtipSZ",
         "9d16918481c74120a5b60b684ac94a08ee341f1788575548b8c45098a88a9c29",
         {
             "isCompressed": true,
@@ -288,7 +288,7 @@
         }
     ],
     [
-        "ESErvnPFgcHX6u6S1cJPmenMZch5KWXfXu",
+        "NUzvcxM1tDZ3TZtAVzxmUAE69hqwWsMBKB",
         "63a911fcd13311d90188b372b6f8ab7a853ef052",
         {
             "addrType": "pubkey",
@@ -297,7 +297,7 @@
         }
     ],
     [
-        "3GAceywAUWaRAieMZAyupHPCDu8rkStFhV",
+        "RPknoxL1XS4c9ZK7uFJSVBMTqeJjn5g293",
         "9ec9fc088ce0a02386c787227e699e50256edbae",
         {
             "addrType": "script",
@@ -306,12 +306,12 @@
         }
     ],
     [
-        "EZtH1eG96BSfYZqU46dysWps8N1f48eSjN",
+        "NceLhpDuHniBuEdCYVJMa2GbiTAXJnZz3G",
         "b785720a94fd55e6f1c738fc465918bdd4280464",
         {
             "addrType": "pubkey",
             "isPrivkey": false,
-            "isTestnet": false 
+            "isTestnet": false
         }
     ],
     [
@@ -324,7 +324,7 @@
         }
     ],
     [
-        "EigM4TaYzJjgWYzGuFvubsWG1N6PmX79ZhSRiWwsnRaN2M3dPdAm",
+        "GnoB4id9STZc9oB2eKTQkJq5VSuXTNuKqtAFYsoCf88KxypKEPS9",
         "bcf8a68ca0454f7a356a9c3e30d8f25ae30d9218a58861bea11b4ccfbdce83fa",
         {
             "isCompressed": true,
@@ -333,7 +333,7 @@
         }
     ],
     [
-        "Ej9wzBhpQW2pmmvy6NMwuxTLjmGKECoExHULSrWFrrhpR7GRcsrE",
+        "GoGmzSkQrerkR27iqRtT4PnADr5Sv4bREUCAHDMajZFnMk6EmF1x",
         "cb2bbfe7aba4c95555da06409432cae7fd3a7ff59471c0e33744c27d49729340",
         {
             "isCompressed": true,
@@ -360,7 +360,7 @@
         }
     ],
     [
-        "EcNYM6CFUMmkKWpkGBfxA8xGkV5UX73AGJ",
+        "Nf8c3GA1fy3GgBcUkaLKreQ1LaELjJxobG",
         "d2ce252de1e1dd9d1205a9672b274f488d943c92",
         {
             "addrType": "pubkey",
@@ -369,7 +369,7 @@
         }
     ],
     [
-        "3FYQkamXxLJwsTW99uLCLKoB3Y8iZYctxP",
+        "RP8auZAP1Fo8rJAuVyej1DmSfHJbiF2mwB",
         "97f112c9c50ac814a953202f485eedfd2cf856b5",
         {
             "addrType": "script",
@@ -396,7 +396,7 @@
         }
     ],
     [
-        "Efqk5KgRm256U7JXXwvfPUHxZwRoB8n9S5v3H9121qsyfDKyas6P",
+        "Gjxa5aj2DAu27MVHH1TAXucn42EvrzaKiGds7VrLtYRwbr8mFxxC",
         "684b0d908dfa54a9a9ea86f0b95b8a570ffe6c705b21c98f8753f0e152234cc7",
         {
             "isCompressed": true,
@@ -405,7 +405,7 @@
         }
     ],
     [
-        "Eka3BjByRHYt7rD8osothqxZy9ckxLwSD5oERuB5EMCq8TbBiBZC",
+        "GpgsBzEZsSNom6PtYwLPrHHPTERteCjcVGX4GG2Q73ko56StRWee",
         "f566a26ae4e40f6dc430c8b554fa9f9a9dcb2241c5d6e91bd6974b8efbd13604",
         {
             "isCompressed": true,
@@ -432,7 +432,7 @@
         }
     ],
     [
-        "EMMJdFm6Q8wKfqaddUsJ7BMjWBa38nVMuD",
+        "NQ7NKRirbkCr2WNN7sXfogoU6GiuHVqN2b",
         "2e0863783ae131b41bcac197738de589881a59c9",
         {
             "addrType": "pubkey",
@@ -441,7 +441,7 @@
         }
     ],
     [
-        "3M3Mh6QKmWjcFN4y3t9vWx6gitGWXAMchY",
+        "RUdXr4oApSDoECjjPxUTBr4xLdSPZXKDHt",
         "d44335f13c8d26c9ba5106b2d4f179ed5a650286",
         {
             "addrType": "script",

--- a/src/test/data/bip39_vectors.json
+++ b/src/test/data/bip39_vectors.json
@@ -3,144 +3,144 @@
         "00000000000000000000000000000000",
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
         "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
-        "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF"
+        "nprvGnNBAhy3NGmY3qnuUjp6v9mCqzFdvA98GSCxixBR7h3Ud7CUPiCkcjWn3wUcbGMPyDLAQfsG9x5NfTM7V1n7WShbAM7nZAv1c51rq2sHMZgp"
     ],
     [
         "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
         "legal winner thank year wave sausage worth useful legal winner thank yellow",
         "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607",
-        "xprv9s21ZrQH143K2gA81bYFHqU68xz1cX2APaSq5tt6MFSLeXnCKV1RVUJt9FWNTbrrryem4ZckN8k4Ls1H6nwdvDTvnV7zEXs2HgPezuVccsq"
+        "nprvGnNBAhy3NGmY3pn1wXrvaUTu8WfaM6xUxV7pUmZATr7HAxd9GyQ3tDudG4gB98K1pFy9JipoTvSaRwyJJCfdSQZ7ApNxhn8AN4G6xnY4b7qT"
     ],
     [
         "80808080808080808080808080808080",
         "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
         "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8",
-        "xprv9s21ZrQH143K2shfP28KM3nr5Ap1SXjz8gc2rAqqMEynmjt6o1qboCDpxckqXavCwdnYds6yBHZGKHv7ef2eTXy461PXUjBFQg6PrwY4Gzq"
+        "nprvGnNBAhy3NGmY3pyZUuHWeXgDtSsQLvyCnEDygXq8Cr6pd5qFBSvt4XdYCt3RcCJ5ALdH6J8HgjbPdvQD8kXiSwscJ7uEF2KUbBFoheU4vg8b"
     ],
     [
         "ffffffffffffffffffffffffffffffff",
         "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
         "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069",
-        "xprv9s21ZrQH143K2V4oox4M8Zmhi2Fjx5XK4Lf7GKRvPSgydU3mjZuKGCTg7UPiBUD7ydVPvSLtg9hjp7MQTYsW67rZHAXeccqYqrsx8LcXnyd"
+        "nprvGnNBAhy3NGmY3pavdLDSgKCCk5ir5SWz79t2kwyiHtJXowZQrPUwmzdn42u4UrBN5NcywahXcETY7RDeRZRZJaTVoK4NNAD8tcSbFuviyVUz"
     ],
     [
         "000000000000000000000000000000000000000000000000",
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
         "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa",
-        "xprv9s21ZrQH143K3mEDrypcZ2usWqFgzKB6jBBx9B6GfC7fu26X6hPRzVjzkqkPvDqp6g5eypdk6cyhGnBngbjeHTe4LsuLG1cCmKJka5SMkmU"
+        "nprvGnNBAhy3NGmY3qs63PFCwjfLutXr2UkdtpiZbpqNeA3xWD7TbkcRtiw4NgGRAavzmVfaCe5pTevp4stUonURSmoHJNmk3obuYXu24MhGF64X"
     ],
     [
         "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
         "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
         "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd",
-        "xprv9s21ZrQH143K3Lv9MZLj16np5GzLe7tDKQfVusBni7toqJGcnKRtHSxUwbKUyUWiwpK55g1DUSsw76TF1T93VT4gz4wt5RM23pkaQLnvBh7"
+        "nprvGnNBAhy3NGmY3qSmxspj4BjDrSyag8ZM1Qx39bXUACyje9PdhSEUM1tGrs1zFeBfgLoocjwBw2kiJiCkG7Kpqynhw1xnbd1eMpQTtBwZqary"
     ],
     [
         "808080808080808080808080808080808080808080808080",
         "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
         "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65",
-        "xprv9s21ZrQH143K3VPCbxbUtpkh9pRG371UCLDz3BjceqP1jz7XZsQ5EnNkYAEkfeZp62cDNj13ZTEVG1TEro9sZ9grfRmcYWLBhCocViKEJae"
+        "nprvGnNBAhy3NGmY3qbF28Dyp5TBjXX1bXYUGHsbdir1z9hDr45UcDnSXyDh8TauXLMimV26m2zBm7m4rs7kFxfqg3VL6hKcL66dXTnWvHJusGbe"
     ],
     [
         "ffffffffffffffffffffffffffffffffffffffffffffffff",
         "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
         "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528",
-        "xprv9s21ZrQH143K36Ao5jHRVhFGDbLP6FCx8BEEmpru77ef3bmA928BxsqvVM27WnvvyfWywiFN8K6yToqMaGYfzS6Db1EHAXT5TuyCLBXUfdm"
+        "nprvGnNBAhy3NGmY3qC2cbzfkgKgJbHviagfkDibtTV9GbyVVMh8EnwAehKAJQmgtBW5tNf1XbyS5gcwM4v8Ng9EUUmjTcu4zi7kREVgW7kAmcUc"
     ],
     [
         "0000000000000000000000000000000000000000000000000000000000000000",
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
         "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
-        "xprv9s21ZrQH143K32qBagUJAMU2LsHg3ka7jqMcV98Y7gVeVyNStwYS3U7yVVoDZ4btbRNf4h6ibWpY22iRmXq35qgLs79f312g2kj5539ebPM"
+        "nprvGnNBAhy3NGmY3q8h16wrdLyu4iZt1YC2uqNjGAoQucYLUp4jXYratmuSMQvTzDmkqzQsCixHS9peud91SsQWqaBKatzzNabL1oLSNrgR72wE"
     ],
     [
         "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
         "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
         "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87",
-        "xprv9s21ZrQH143K3Y1sd2XVu9wtqxJRvybCfAetjUrMMco6r3v9qZTBeXiBZkS8JxWbcGJZyio8TrZtm6pkbzG8SYt1sxwNLh3Wx7to5pgiVFU"
+        "nprvGnNBAhy3NGmY3qdsh9Huq5nNwDetmRR3zki2YR98irUdwA9HEVUVeNy2ZVB6tyffZ1Fo7dyyr2AQGND7mhrwvvtXFurn5tHLrihc6sMCqncL"
     ],
     [
         "8080808080808080808080808080808080808080808080808080808080808080",
         "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
         "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f",
-        "xprv9s21ZrQH143K3CSnQNYC3MqAAqHwxeTLhDbhF43A4ss4ciWNmCY9zQGvAKUSqVUf2vPHBTSE1rB2pg4avopqSiLVzXEU8KziNnVPauTqLRo"
+        "nprvGnNBAhy3NGmY3qJJbvdvXDzGCYXtHT5v8nkyLviKXZjhtvosTR7aciqbJ5k9DWCdcRuspqicwaA1QRnMc2gWdw3yk2R5BfvJ49NChNUGMYgs"
     ],
     [
         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
         "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad",
-        "xprv9s21ZrQH143K2WFF16X85T2QCpndrGwx6GueB72Zf3AHwHJaknRXNF37ZmDrtHrrLSHvbuRejXcnYxoZKvRquTPyp2JiNG3XcjQyzSEgqCB"
+        "nprvGnNBAhy3NGmY3pc74XMuTG5TSaXNyLiQkBpHHrmJw9u18FNffQhTz6gMVVBtdZ11ojRnUGAcNHqTAA56aRo7ePo3Dqv9RurLsPK8Hn3PhrfX"
     ],
     [
         "9e885d952ad362caeb4efe34a8e91bd2",
         "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
         "274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028",
-        "xprv9s21ZrQH143K2oZ9stBYpoaZ2ktHj7jLz7iMqpgg1En8kKFTXJHsjxry1JbKH19YrDTicVwKPehFKTbmaxgVEc5TpHdS1aYhB2s9aFJBeJH"
+        "nprvGnNBAhy3NGmY3puQyQ9Zt1S1bQTUdDZC95f61XUy3W6cy4QcYBDLLUQBLvjG5wiJWFCxGGm82wxXcvZtngqNHiwihrBU9ZAr2wcaTMqtKCNE"
     ],
     [
         "6610b25967cdcca9d59875f5cb50b0ea75433311869e930b",
         "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
         "628c3827a8823298ee685db84f55caa34b5cc195a778e52d45f59bcf75aba68e4d7590e101dc414bc1bbd5737666fbbef35d1f1903953b66624f910feef245ac",
-        "xprv9s21ZrQH143K3uT8eQowUjsxrmsA9YUuQQK1RLqFufzybxD6DH6gPY7NjJ5G3EPHjsWDrs9iivSbmvjc9DQJbJGatfa9pv4MZ3wjr8qWPAK"
+        "nprvGnNBAhy3NGmY3r1JxAgCGfNK1EUTVdywhVwgf717dQXqov3aAsC997yRkeik2hwYF8rzmX8LSHEGyP32dF6675dupvZQsNWMhKdf3djbQmj4"
     ],
     [
         "68a79eaca2324873eacc50cb9c6eca8cc68ea5d936f98787c60c7ebc74e6ce7c",
         "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
         "64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440",
-        "xprv9s21ZrQH143K2XTAhys3pMNcGn261Fi5Ta2Pw8PwaVPhg3D8DWkzWQwjTJfskj8ofb81i9NP2cUNKxwjueJHHMQAnxtivTA75uUFqPFeWzk"
+        "nprvGnNBAhy3NGmY3pdJzEFFNzyoeeUcRVhAsZ7Q3cngK5MEXz8aCsRoTErG7NjLeRSHm4acZNQZ6avJjw5Em1Wz5mh3QprjSU3TSrVBZczz6dC5"
     ],
     [
         "c0ba5a8e914111210f2bd131f3d5e08d",
         "scheme spot photo card baby mountain device kick cradle pact join borrow",
         "ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612",
-        "xprv9s21ZrQH143K3FperxDp8vFsFycKCRcJGAFmcV7umQmcnMZaLtZRt13QJDsoS5F6oYT6BB4sS6zmTmyQAEkJKxJ7yByDNtRe5asP2jFGhT6"
+        "nprvGnNBAhy3NGmY3qMgUPDc9KYgudgCegs56MhdRJ9QHGGcT6SvezobtcSMnDeYa6nQ4CXwdqSFazQq94tGRG7S6pHwN15ovvUiyrAagpKheAQU"
     ],
     [
         "6d9be1ee6ebd27a258115aad99b7317b9c8d28b6d76431c3",
         "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
         "fd579828af3da1d32544ce4db5c73d53fc8acc4ddb1e3b251a31179cdb71e853c56d2fcb11aed39898ce6c34b10b5382772db8796e52837b54468aeb312cfc3d",
-        "xprv9s21ZrQH143K3R1SfVZZLtVbXEB9ryVxmVtVMsMwmEyEvgXN6Q84LKkLRmf4ST6QrLeBm3jQsb9gx1uo23TS7vo3vAkZGZz71uuLCcywUkt"
+        "nprvGnNBAhy3NGmY3qWsGBkwtXWvdtvmVMQxks3G93XeKG6p5EmtSkKAX4m4iMCKq7AFNFL8jRJv8Rtz4Z8Cp7v9EcGSHx4bGpAHSnVcdzD2Vtds"
     ],
     [
         "9f6a2878b2520799a44ef18bc7df394e7061a224d2c33cd015b157d746869863",
         "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
         "72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d",
-        "xprv9s21ZrQH143K2WNnKmssvZYM96VAr47iHUQUTUyUXH3sAGNjhJANddnhw3i3y3pBbRAVk5M5qUGFr4rHbEWwXgX4qrvrceifCYQJbbFDems"
+        "nprvGnNBAhy3NGmY3pcEbr3GD7ByPWo5WLVaWP1n899Fr28thUMjpMDCqN575rUNpdky8zQf3QLXoPn6dTB9Jh7Ck22AJskmaAF1zy87cPEvxGsg"
     ],
     [
         "23db8160a31d3e0dca3688ed941adbf3",
         "cat swing flag economy stadium alone churn speed unique patch report train",
         "deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5",
-        "xprv9s21ZrQH143K4G28omGMogEoYgDQuigBo8AFHAGDaJdqQ99QKMQ5J6fYTMfANTJy6xBmhvsNZ1CJzRZ64PWbnTFUn6CDV2FxoMDLXdk95DQ"
+        "nprvGnNBAhy3NGmY3rMsxL2egzJfqvNokQA8ytfXtxpYb5AUfiEWUyGSY2XyvNnKw3ATvVwgKNC467K2gbXr7AGCQGntioz2w2cZJZvveKBfgNeP"
     ],
     [
         "8197a4a47f0425faeaa69deebc05ca29c0a5b5cc76ceacc0",
         "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
         "4cbdff1ca2db800fd61cae72a57475fdc6bab03e441fd63f96dabd1f183ef5b782925f00105f318309a7e9c3ea6967c7801e46c8a58082674c860a37b93eda02",
-        "xprv9s21ZrQH143K3wtsvY8L2aZyxkiWULZH4vyQE5XkHTXkmx8gHo6RUEfH3Jyr6NwkJhvano7Xb2o6UqFKWHVo5scE31SGDCAUsgVhiUuUDyh"
+        "nprvGnNBAhy3NGmY3r3khSoWfDD12LTJqxn25AUM3ujp7nKNb63Vkwi8tCfyexjecm66hhhR8T4JF9LdU5wYLcABbaDFU4uGyknTpeGD1W3We7iV"
     ],
     [
         "066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad",
         "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
         "26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d",
-        "xprv9s21ZrQH143K3rEfqSM4QZRVmiMuSWY9wugscmaCjYja3SbUD3KPEB1a7QXJoajyR2T1SiXU7rFVRXMV9XdYVSZe7JoUXdP4SRHTxsT1nzm"
+        "nprvGnNBAhy3NGmY3qx6VMhjPbBrY9QxEvwzx3T4XJRraEQaQMXxYrxMqxcKx2qC5UHtvp1wZ6yiBgA5s2deWFQKLynCt9CeC5DgQCzzmkTYqxXv"
     ],
     [
         "f30f8c1da665478f49b001d94c5fc452",
         "vessel ladder alter error federal sibling chat ability sun glass valve picture",
         "2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f",
-        "xprv9s21ZrQH143K2QWV9Wn8Vvs6jbqfF1YbTCdURQW9dLFKDovpKaKrqS3SEWsXCu6ZNky9PSAENg6c9AQYHcg4PjopRGGKmdD313ZHszymnps"
+        "nprvGnNBAhy3NGmY3pWNJfnATgZJ97JRzjT1PYk1874nX8C69XuHtyVNKZsMp9wYHscFWmkTh3hLwvyvykGhZPVMrt5T4TA73KDWNmdGbfduyQTq"
     ],
     [
         "c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05",
         "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
         "7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88",
-        "xprv9s21ZrQH143K4aERa2bq7559eMCCEs2QmmqVjUuzfy5eAeDX4mqZffkYwpzGQRE2YEEeLVRoH4CSHxianrFaVnMN2RYaPUZJhJx8S5j6puX"
+        "nprvGnNBAhy3NGmY3rg6F6HzAHhWC23nXjJVCsKD9R9CNApvUUjabigt2Q74vsFf358NywDjBzkcWqN2ou51btiwNz7zc4KPHw4reTtfSDbVDEJB"
     ],
     [
         "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
         "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
         "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
-        "xprv9s21ZrQH143K39rnQJknpH1WEPFJrzmAqqasiDcVrNuk926oizzJDDQkdiTvNPr2FYDYzWgiMiC63YmfPAa2oPyNB23r2g7d1yiK6WpqaQS"
+        "nprvGnNBAhy3NGmY3qFibva97zuSYc5qeMSDxwNxXPstsMEkaT7TtNv2kwej8Z98h36zyeXi6emsRv22Tef4gV3FqHjccCutZaGQxnZRcszxYE43"
     ]
 ]

--- a/src/test/data/proposals-valid.json
+++ b/src/test/data/proposals-valid.json
@@ -1,5 +1,5 @@
 [
-{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
-{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.12345678, "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
-{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 1, "url": "http://[dead:beef:cafe:5417:affe:8FA3:deaf:feed]:/foo/"}
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "EZtH1eG96BSfYZqU46dysWps8N1f48eSjN", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "EZtH1eG96BSfYZqU46dysWps8N1f48eSjN", "payment_amount": 25.12345678, "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "EZtH1eG96BSfYZqU46dysWps8N1f48eSjN", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 1, "url": "http://[dead:beef:cafe:5417:affe:8FA3:deaf:feed]:/foo/"}
 ]

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -18,18 +18,17 @@
 
 using namespace std;
 
-static const string strSecret1     ("Ej3b3UtDHaLBAvnppRbpwzGHhYRBxjRrTvAK9cDYoEctCDVyE298");
-static const string strSecret2     ("EfTHXR9SsWorWr27kqU33gYrzuCnJs5jgMVHNV6RUuCNUCYZbCGo");
-static const string strSecret1C    ("Eegycyw24qQEG88Gxv6NLkbDqL2miwjDZGVHRBVumCxVPMRcGWkq");
-static const string strSecret2C    ("EhcNR2QeFtikrBx4VVa7eBY75xAHPQjsrApGtrQuHSLo8LuuArZv");
-static const CBitcoinAddress addr1 ("ER1oCV1adF3pk3mP4iqZXBGYr4CmQjE8Pb");
-static const CBitcoinAddress addr2 ("ENqqFw8P3DLoY1zvetP4X8qUXmyo8NRFGs");
-static const CBitcoinAddress addr1C("EKMyC5EzKwW4sTioEGgFTbebhtrhFK2miv");
-static const CBitcoinAddress addr2C("ET7cMauEgCGp468V1edL2zupNETJVaDWnw");
+static const string strSecret1     ("4ZZcwP6utR94jqhqXNKeYX19VU5rokGJqNFhaScKNpTRCs5kF6L");
+static const string strSecret2     ("4ZXhhzWHZ4XyYFtbJr4SKVayaRv7994s9uQQ9YHQDGkL46UBYdy");
+static const string strSecret1C    ("Giiyd2Z6RwYbW5yFB37Ji7ReUeYSqKxZiUot6c2t7JTbq8Uo5GqR");
+static const string strSecret2C    ("GiaWfvpG4WbiYxiiRmYAkdAxiYyQ6vc4NJJHAh5PTAWF6Xm9tNmh");
+static const CBitcoinAddress addr1 ("EVpKt56m8W3f4tc3rSSgqVhVqQk817LoeD");
+static const CBitcoinAddress addr2 ("EMptRM8cEE1bLyeHmRBssKybEGrsKEkWiX");
+static const CBitcoinAddress addr1C("EK2PbgCrLPXW76HB84tM7ynZqtVhm8YJtJ");
+static const CBitcoinAddress addr2C("EResuxKDsSzZK2SNvfcn6fTXFnBygDRRb2");
 
 
-static const string strAddressBad("Xta1praZQjyELweyMByXyiREw1ZRsjXzVP");
-
+static const string strAddressBad("Eta1praZQjyELweyMByXyiREw1ZRsjXzVP");
 
 #ifdef KEY_TESTS_DUMPINFO
 void dumpKeyInfo(uint256 privkey)
@@ -71,9 +70,9 @@ BOOST_AUTO_TEST_CASE(key_test1)
     BOOST_CHECK(!baddress1.SetString(strAddressBad));
 
     CKey key1  = bsecret1.GetKey();
-    BOOST_CHECK(key1.IsCompressed() == true);
+    BOOST_CHECK(key1.IsCompressed() == false);
     CKey key2  = bsecret2.GetKey();
-    BOOST_CHECK(key2.IsCompressed() == true);
+    BOOST_CHECK(key2.IsCompressed() == false);
     CKey key1C = bsecret1C.GetKey();
     BOOST_CHECK(key1C.IsCompressed() == true);
     CKey key2C = bsecret2C.GetKey();

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -33,26 +33,23 @@ static const string strAddressBad("Eta1praZQjyELweyMByXyiREw1ZRsjXzVP");
 #ifdef KEY_TESTS_DUMPINFO
 void dumpKeyInfo(uint256 privkey)
 {
-    CKey key;
-    key.resize(32);
-    memcpy(&secret[0], &privkey, 32);
-    vector<unsigned char> sec;
-    sec.resize(32);
-    memcpy(&sec[0], &secret[0], 32);
-    printf("  * secret (hex): %s\n", HexStr(sec).c_str());
-
     for (int nCompressed=0; nCompressed<2; nCompressed++)
     {
         bool fCompressed = nCompressed == 1;
+
+        CKey key;
+        key.Set(privkey.begin(), privkey.end(), fCompressed);
+
         printf("  * %s:\n", fCompressed ? "compressed" : "uncompressed");
         CBitcoinSecret bsecret;
-        bsecret.SetSecret(secret, fCompressed);
+        bsecret.SetKey(key);
         printf("    * secret (base58): %s\n", bsecret.ToString().c_str());
-        CKey key;
-        key.SetSecret(secret, fCompressed);
-        vector<unsigned char> vchPubKey = key.GetPubKey();
+
+        CPubKey vchPubKey = key.GetPubKey();
+        CKeyID keyID = vchPubKey.GetID();
+        CBitcoinAddress keyAddress(keyID);
         printf("    * pubkey (hex): %s\n", HexStr(vchPubKey).c_str());
-        printf("    * address (base58): %s\n", CBitcoinAddress(vchPubKey).ToString().c_str());
+        printf("    * address (base58): %s\n", CBitcoinAddress(keyAddress).ToString().c_str());
     }
 }
 #endif


### PR DESCRIPTION
* Allows Energi Backbone payment to use P2SH addresses
* Changed main net prefixes (E for p2pkh, N for p2sh, G for private key, npub for hd pub, nprv for hd private)
* updated unit tests to reflect changes to address prefixes