### PR TITLE
Refactor includes in pos_kernel header

### DIFF
--- a/src/pos_kernel.cpp
+++ b/src/pos_kernel.cpp
@@ -5,17 +5,22 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <boost/assign/list_of.hpp>
-#include <boost/lexical_cast.hpp>
+#include "pos_kernel.h"
 
+#include "chain.h"
 #include "chainparams.h"
 #include "db.h"
-#include "pos_kernel.h"
 #include "script/interpreter.h"
+#include "primitives/block.h"
 #include "policy/policy.h"
 #include "timedata.h"
 #include "util.h"
+#include "uint256.h"
+#include "validation.h"
 #include "consensus/validation.h"
+
+#include <boost/assign/list_of.hpp>
+#include <boost/lexical_cast.hpp>
 
 using namespace std;
 

--- a/src/pos_kernel.h
+++ b/src/pos_kernel.h
@@ -6,9 +6,19 @@
 #ifndef BITCOIN_KERNEL_H
 #define BITCOIN_KERNEL_H
 
+#include "amount.h"
 #include "streams.h"
-#include "validation.h"
 
+class CBlockIndex;
+class CBlockHeader;
+class CTransaction;
+class COutPoint;
+class CValidationState;
+class uint256;
+
+namespace Consensus {
+    class Params;
+}
 
 static constexpr CAmount MIN_STAKE_AMOUNT = COIN;
 static constexpr int64_t MAX_POS_BLOCK_AHEAD_TIME = 180;


### PR DESCRIPTION
I don't think it is a good idea to have the `#include "validation.h"` in the pos_kernel header file (`pos_kernel.h`). It might cause circular dependencies between classes in the future.

Instead, I added forward declarations for the needed classes and moved the header includes it needs to the pos_kernel implementation file (`pos_kernel.cpp`). 