### PR TITLE
Fix small out-of-bounds read in validation.cpp

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5056,7 +5056,7 @@ bool PassStakeInputThrottle(CValidationState& state, const COutPoint &out) {
         for (auto iter = mapStakeInputSeen.begin(); iter != mapStakeInputSeen.end();) {
             auto curr = iter++;
 
-            if ((iter->second + STAKE_INPUT_THROTTLE_PERIOD) < now) {
+            if ((curr->second + STAKE_INPUT_THROTTLE_PERIOD) < now) {
                 mapStakeInputSeen.erase(curr);
             }
         }


### PR DESCRIPTION
Looks like there is a small typo here.  It leads to a relatively harmless out-of-bounds read, but it is worth fixing.